### PR TITLE
Improve multiple license prohibition check and config path detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ module.exports = {
         "name": "allowed-package-name-here",
       }
   ],
-    allowedLicenses: [
+    "allowedLicenses": [
       "MIT"
     ]
   }

--- a/bin/license-to-fail.js
+++ b/bin/license-to-fail.js
@@ -32,7 +32,9 @@ if (configPath) {
   }
 }
 
-config.configPath = path.resolve(configPath);
+if (configPath) {
+  config.configPath = path.resolve(configPath);
+}
 config.__currentPackage = {
   name: packageJson.name,
   dependencies: packageJson.dependencies || [],

--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ module.exports = function checkLicenses(config) {
       console.log('');
       console.log('Disallowed Licenses:');
       prohibitedDeps.sort(function(a, b) {
-        var aLower = Array.isArray(a) ? a.licenses[0].toLowerCase() : a.licenses.toLowerCase();
-        var bLower = Array.isArray(b) ? b.licenses[0].toLowerCase() : b.licenses.toLowerCase();
+        var aLower = Array.isArray(a.licenses) ? a.licenses[0].toLowerCase() : a.licenses.toLowerCase();
+        var bLower = Array.isArray(b.licenses) ? b.licenses[0].toLowerCase() : b.licenses.toLowerCase();
         return aLower < bLower ? -1 : aLower > bLower ? 1 : 0;
       });
       prohibitedDeps.map(function(dep) { log(dep); });


### PR DESCRIPTION
`path.resolve(configPath)` was throwing errors for me as I was using `package.json` for config.

Packages with multiple licenses were also causing errors, so this fixes that.
