### PR TITLE
Support legacy npm package names containing upper case characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 config.js
+package-lock.json

--- a/example-config.js
+++ b/example-config.js
@@ -23,6 +23,9 @@ module.exports = {
       "name": "humane-js@3.2.2",
       "repo": "https://github.com/wavded/humane-js",
       "reason": "MIT in the README"
+    },
+    {
+      "name": "spdx-exceptions"
     }
   ],
   "disallowedPackages": [],
@@ -34,6 +37,7 @@ module.exports = {
     "WTF",
     "Public Domain",
     "MPL",
+    "CC-BY-3.0",
     "Unlicense"
   ]
 };

--- a/src/__tests__/check-licenses.test.js
+++ b/src/__tests__/check-licenses.test.js
@@ -1,14 +1,14 @@
 import test from 'ava';
 
 test('should fail on BSD-3-Clause if in strict mode and only BSD is whitelisted', (t) => {
-  var checkLicenses = require('../check-licenses');
-  var config = {
+  const checkLicenses = require('../check-licenses');
+  const config = {
     'allowedLicenses': [
       'BSD'
     ],
     'strictMode': true
   };
-  var sampleDependency = {
+  const sampleDependency = {
     name: 'foo@1.0.0',
     licenses: 'BSD-3-Clause',
     repository: 'https://github.com/foo',
@@ -19,20 +19,20 @@ test('should fail on BSD-3-Clause if in strict mode and only BSD is whitelisted'
 });
 
 test('should pass if license is BSD or MIT if only BSD is whitelisted in strictMode', (t) => {
-  var checkLicenses = require('../check-licenses');
-  var config = {
+  const checkLicenses = require('../check-licenses');
+  const config = {
     'allowedLicenses': [
       'BSD'
     ],
     'strictMode': true
   };
-  var sampleDependency = {
+  const sampleDependency = {
     name: 'foo@1.0.0',
     licenses: 'BSD OR MIT',
     repository: 'https://github.com/foo',
     licenseFile: '/path/to/LICENSE'
   };
-  var sampleDependencyWithParens = {
+  const sampleDependencyWithParens = {
     name: 'foo@1.0.0',
     licenses: '(BSD OR MIT)',
     repository: 'https://github.com/foo',
@@ -41,4 +41,24 @@ test('should pass if license is BSD or MIT if only BSD is whitelisted in strictM
 
   t.is(checkLicenses(config).isAllowedDependency(sampleDependency), true);
   t.is(checkLicenses(config).isAllowedDependency(sampleDependencyWithParens), true);
+});
+
+test('should pass if package name contains upper case characters', (t) => {
+  const checkLicenses = require('../check-licenses');
+  const config = {
+    'allowedPackages': [
+      {
+        "name": "Foo@1.0.0",
+        "reason": "ISC"
+      }
+    ],
+    'allowedLicenses': []
+  };
+  const sampleDependency = {
+    name: 'Foo@1.0.0',
+    repository: 'https://github.com/foo',
+    licenseFile: '/path/to/LICENSE'
+  };
+
+  t.is(checkLicenses(config).isAllowedDependency(sampleDependency), true);
 });

--- a/src/check-licenses.js
+++ b/src/check-licenses.js
@@ -2,7 +2,7 @@ var checker = require('license-checker');
 
 function isAllowedPackage(allowedPackages, dependency) {
   return allowedPackages.some(function(pkg) {
-    return pkg.name.indexOf(dependency.name.toLowerCase().split('@')[0]) !== -1;
+    return pkg.name.toLowerCase().indexOf(dependency.name.toLowerCase().split('@')[0]) !== -1;
   });
 }
 


### PR DESCRIPTION
Letter casing in the license-to-fail config list of package names should not matter. This patch normalizes the package name in the config file before checking it against a given dependency. This only affects npm packages created before npm began enforcing lower case characters in package names.

This bug was discovered when trying to add a license exception for https://github.com/lloyd/JSONSelect